### PR TITLE
Adding a test to ensure no diagnostics are triggered for any non-matching annotation or import path similar to "jakarta.annotation.PostConstruct"

### DIFF
--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
@@ -31,10 +31,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import static io.openliberty.tools.intellij.lsp4jakarta.it.core.JakartaForJavaAssert.*;
 

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
@@ -55,29 +55,21 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
 
         // expected Diagnostics
 
-        Diagnostic d1 = d(16, 19, 31, "A method with the @PostConstruct annotation must be void.",
+        Diagnostic d1 = d(15, 19, 31, "A method with the @PostConstruct annotation must be void.",
                 DiagnosticSeverity.Error, "jakarta-annotations", "PostConstructReturnType");
 
-        Diagnostic d2 = d(21, 16, 28, "A method with the @PostConstruct annotation must not have any parameters.",
+        Diagnostic d2 = d(20, 16, 28, "A method with the @PostConstruct annotation must not have any parameters.",
                 DiagnosticSeverity.Error, "jakarta-annotations", "PostConstructParams");
 
-        Diagnostic d3 = d(26, 16, 28, "A method with the @PostConstruct annotation must not throw checked exceptions.",
+        Diagnostic d3 = d(25, 16, 28, "A method with the @PostConstruct annotation must not throw checked exceptions.",
                 DiagnosticSeverity.Warning, "jakarta-annotations", "PostConstructException");
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
 
-        // Adding a test to ensure no diagnostics are triggered for any non-matching annotation or import path similar to "jakarta.annotation.PostConstruct"
-        JakartaJavaDiagnosticsParams nonMatchingAnnotationParams = new JakartaJavaDiagnosticsParams();
-        nonMatchingAnnotationParams.setUris(Arrays.asList(uri));
-
-        // Ensure no diagnostics are generated for any annotation or import that is not exactly "jakarta.annotation.PostConstruct"
-        //assertJavaDiagnostics(nonMatchingAnnotationParams, utils);
-
         // Starting codeAction tests.
         String newText = "package io.openliberty.sample.jakarta.annotations;\n\n" +
                 "import jakarta.annotation.PostConstruct;\n" +
-                "import jakarta.annotation.Resource;\n" +
-                "import random.test.pkg.on.PostConstruct;\n\n" +
+                "import jakarta.annotation.Resource;\n\n" +
                 "@Resource(type = Object.class, name = \"aa\")\n" +
                 "public class PostConstructAnnotation {\n\n" +
                 "    private Integer studentId;\n\n    private boolean isHappy;\n\n" +
@@ -88,21 +80,16 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "    public void throwTantrum() throws Exception {\n" +
                 "        System.out.println(\"I'm sad\");\n    }\n\n" +
                 "    private String emailAddress;\n\n" +
-                "    @random.test.pkg.on.PostConstruct\n" +
-                "    public void getHappinessRandom(String type) {\n" +
-                "\n" +
-                "    }\n\n" +
                 "}";
 
         JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d1);
-        TextEdit te3 = te(0, 0, 37, 1, newText);
+        TextEdit te3 = te(0, 0, 31, 1, newText);
         CodeAction ca3 = ca(uri, "Change return type to void", d1, te3);
         assertJavaCodeAction(codeActionParams2, utils, ca3);
 
         String newText1 = "package io.openliberty.sample.jakarta.annotations;\n\n" +
                 "import jakarta.annotation.PostConstruct;\n" +
-                "import jakarta.annotation.Resource;\n" +
-                "import random.test.pkg.on.PostConstruct;\n\n" +
+                "import jakarta.annotation.Resource;\n\n" +
                 "@Resource(type = Object.class, name = \"aa\")\n" +
                 "public class PostConstructAnnotation {\n\n" +
                 "    private Integer studentId;\n\n    private boolean isHappy;\n\n" +
@@ -113,16 +100,11 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "    public void throwTantrum() throws Exception {\n" +
                 "        System.out.println(\"I'm sad\");\n    }\n\n" +
                 "    private String emailAddress;\n\n" +
-                "    @random.test.pkg.on.PostConstruct\n" +
-                "    public void getHappinessRandom(String type) {\n" +
-                "\n" +
-                "    }\n\n" +
                 "}";
 
         String newText2 = "package io.openliberty.sample.jakarta.annotations;\n\n" +
                 "import jakarta.annotation.PostConstruct;\n" +
-                "import jakarta.annotation.Resource;\n" +
-                "import random.test.pkg.on.PostConstruct;\n\n" +
+                "import jakarta.annotation.Resource;\n\n" +
                 "@Resource(type = Object.class, name = \"aa\")\n" +
                 "public class PostConstructAnnotation {\n\n    " +
                 "private Integer studentId;\n\n    " +
@@ -137,17 +119,34 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "public void throwTantrum() throws Exception {\n        " +
                 "System.out.println(\"I'm sad\");\n    }\n\n    " +
                 "private String emailAddress;\n\n" +
-                "    @random.test.pkg.on.PostConstruct\n" +
-                "    public void getHappinessRandom(String type) {\n" +
-                "\n" +
-                "    }\n\n" +
                 "}";
 
         JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
-        TextEdit te = te(0, 0, 37, 1, newText1);
-        TextEdit te1 = te(0, 0, 37, 1, newText2);
+        TextEdit te = te(0, 0, 31, 1, newText1);
+        TextEdit te1 = te(0, 0, 31, 1, newText2);
         CodeAction ca = ca(uri, "Remove @PostConstruct", d2, te);
         CodeAction ca1 = ca(uri, "Remove all parameters", d2, te1);
         assertJavaCodeAction(codeActionParams1, utils, ca, ca1);
+    }
+
+    @Test
+    public void testIncorrectPostConstructAnnotation() throws Exception {
+        // Set up the module and file where a non-Jakarta PostConstruct annotation is used
+        Module module = createMavenModule(new File("src/test/resources/projects/maven/jakarta-sample"));
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(getProject());
+
+        // The file path to a Java file that includes an incorrectly qualified PostConstruct annotation
+        VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(
+                ModuleUtilCore.getModuleDirPath(module) +
+                        "/src/main/java/io/openliberty/sample/jakarta/annotations/IncorrectPostConstructAnnotation.java"
+        );
+        String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
+
+        // Adding a test to ensure no diagnostics are triggered for any non-matching annotation or import path similar to "jakarta.annotation.PostConstruct"
+        JakartaJavaDiagnosticsParams diagnosticsParams = new JakartaJavaDiagnosticsParams();
+        diagnosticsParams.setUris(Arrays.asList(uri));
+
+        // Ensure no diagnostics are generated for any annotation or import that is not exactly "jakarta.annotation.PostConstruct"
+        assertJavaDiagnostics(diagnosticsParams, utils);
     }
 }

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
@@ -55,13 +55,13 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
 
         // expected Diagnostics
 
-        Diagnostic d1 = d(17, 19, 31, "A method with the @PostConstruct annotation must be void.",
+        Diagnostic d1 = d(16, 19, 31, "A method with the @PostConstruct annotation must be void.",
                 DiagnosticSeverity.Error, "jakarta-annotations", "PostConstructReturnType");
 
-        Diagnostic d2 = d(22, 16, 28, "A method with the @PostConstruct annotation must not have any parameters.",
+        Diagnostic d2 = d(21, 16, 28, "A method with the @PostConstruct annotation must not have any parameters.",
                 DiagnosticSeverity.Error, "jakarta-annotations", "PostConstructParams");
 
-        Diagnostic d3 = d(27, 16, 28, "A method with the @PostConstruct annotation must not throw checked exceptions.",
+        Diagnostic d3 = d(26, 16, 28, "A method with the @PostConstruct annotation must not throw checked exceptions.",
                 DiagnosticSeverity.Warning, "jakarta-annotations", "PostConstructException");
 
         assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
@@ -71,14 +71,13 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
         nonMatchingAnnotationParams.setUris(Arrays.asList(uri));
 
         // Ensure no diagnostics are generated for any annotation or import that is not exactly "jakarta.annotation.PostConstruct"
-        assertJavaDiagnostics(nonMatchingAnnotationParams, utils, null);
+        //assertJavaDiagnostics(nonMatchingAnnotationParams, utils);
 
         // Starting codeAction tests.
         String newText = "package io.openliberty.sample.jakarta.annotations;\n\n" +
                 "import jakarta.annotation.PostConstruct;\n" +
-                "import jakarta.annotation.Resource;\n\n" +
-                "import my.random.pkg.PostConstruct;\n" +
-                "import on.PostConstruct;\n" +
+                "import jakarta.annotation.Resource;\n" +
+                "import testannotation.on.PostConstruct;\n\n" +
                 "@Resource(type = Object.class, name = \"aa\")\n" +
                 "public class PostConstructAnnotation {\n\n" +
                 "    private Integer studentId;\n\n    private boolean isHappy;\n\n" +
@@ -89,20 +88,21 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "    public void throwTantrum() throws Exception {\n" +
                 "        System.out.println(\"I'm sad\");\n    }\n\n" +
                 "    private String emailAddress;\n\n" +
+                "    @on.PostConstruct\n" +
+                "    public void nonMatchingMethod() {\n" +
                 "        System.out.println(\"This should not trigger diagnostics.\");\n" +
-                "    }" +
+                "    }\n\n" +
                 "}";
 
         JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d1);
-        TextEdit te3 = te(0, 0, 38, 1, newText);
+        TextEdit te3 = te(0, 0, 37, 1, newText);
         CodeAction ca3 = ca(uri, "Change return type to void", d1, te3);
         assertJavaCodeAction(codeActionParams2, utils, ca3);
 
         String newText1 = "package io.openliberty.sample.jakarta.annotations;\n\n" +
                 "import jakarta.annotation.PostConstruct;\n" +
-                "import jakarta.annotation.Resource;\n\n" +
-                "import my.random.pkg.PostConstruct;\n" +
-                "import on.PostConstruct;\n" +
+                "import jakarta.annotation.Resource;\n" +
+                "import testannotation.on.PostConstruct;\n\n" +
                 "@Resource(type = Object.class, name = \"aa\")\n" +
                 "public class PostConstructAnnotation {\n\n" +
                 "    private Integer studentId;\n\n    private boolean isHappy;\n\n" +
@@ -113,15 +113,16 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "    public void throwTantrum() throws Exception {\n" +
                 "        System.out.println(\"I'm sad\");\n    }\n\n" +
                 "    private String emailAddress;\n\n" +
+                "    @on.PostConstruct\n" +
+                "    public void nonMatchingMethod() {\n" +
                 "        System.out.println(\"This should not trigger diagnostics.\");\n" +
-                "    }" +
+                "    }\n\n" +
                 "}";
 
         String newText2 = "package io.openliberty.sample.jakarta.annotations;\n\n" +
                 "import jakarta.annotation.PostConstruct;\n" +
-                "import jakarta.annotation.Resource;\n\n" +
-                "import my.random.pkg.PostConstruct;\n" +
-                "import on.PostConstruct;\n" +
+                "import jakarta.annotation.Resource;\n" +
+                "import testannotation.on.PostConstruct;\n\n" +
                 "@Resource(type = Object.class, name = \"aa\")\n" +
                 "public class PostConstructAnnotation {\n\n    " +
                 "private Integer studentId;\n\n    " +
@@ -135,14 +136,16 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "@PostConstruct\n    " +
                 "public void throwTantrum() throws Exception {\n        " +
                 "System.out.println(\"I'm sad\");\n    }\n\n    " +
-                "private String emailAddress;\n\n}" +
+                "private String emailAddress;\n\n" +
+                "    @on.PostConstruct\n" +
+                "    public void nonMatchingMethod() {\n" +
                 "        System.out.println(\"This should not trigger diagnostics.\");\n" +
-                "    }" +
+                "    }\n\n" +
                 "}";
 
         JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
-        TextEdit te = te(0, 0, 38, 1, newText1);
-        TextEdit te1 = te(0, 0, 38, 1, newText2);
+        TextEdit te = te(0, 0, 37, 1, newText1);
+        TextEdit te1 = te(0, 0, 37, 1, newText2);
         CodeAction ca = ca(uri, "Remove @PostConstruct", d2, te);
         CodeAction ca1 = ca(uri, "Remove all parameters", d2, te1);
         assertJavaCodeAction(codeActionParams1, utils, ca, ca1);

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
@@ -77,7 +77,7 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
         String newText = "package io.openliberty.sample.jakarta.annotations;\n\n" +
                 "import jakarta.annotation.PostConstruct;\n" +
                 "import jakarta.annotation.Resource;\n" +
-                "import testannotation.on.PostConstruct;\n\n" +
+                "import random.test.pkg.on.PostConstruct;\n\n" +
                 "@Resource(type = Object.class, name = \"aa\")\n" +
                 "public class PostConstructAnnotation {\n\n" +
                 "    private Integer studentId;\n\n    private boolean isHappy;\n\n" +
@@ -88,9 +88,9 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "    public void throwTantrum() throws Exception {\n" +
                 "        System.out.println(\"I'm sad\");\n    }\n\n" +
                 "    private String emailAddress;\n\n" +
-                "    @on.PostConstruct\n" +
-                "    public void nonMatchingMethod() {\n" +
-                "        System.out.println(\"This should not trigger diagnostics.\");\n" +
+                "    @random.test.pkg.on.PostConstruct\n" +
+                "    public void getHappinessRandom(String type) {\n" +
+                "\n" +
                 "    }\n\n" +
                 "}";
 
@@ -102,7 +102,7 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
         String newText1 = "package io.openliberty.sample.jakarta.annotations;\n\n" +
                 "import jakarta.annotation.PostConstruct;\n" +
                 "import jakarta.annotation.Resource;\n" +
-                "import testannotation.on.PostConstruct;\n\n" +
+                "import random.test.pkg.on.PostConstruct;\n\n" +
                 "@Resource(type = Object.class, name = \"aa\")\n" +
                 "public class PostConstructAnnotation {\n\n" +
                 "    private Integer studentId;\n\n    private boolean isHappy;\n\n" +
@@ -113,16 +113,16 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "    public void throwTantrum() throws Exception {\n" +
                 "        System.out.println(\"I'm sad\");\n    }\n\n" +
                 "    private String emailAddress;\n\n" +
-                "    @on.PostConstruct\n" +
-                "    public void nonMatchingMethod() {\n" +
-                "        System.out.println(\"This should not trigger diagnostics.\");\n" +
+                "    @random.test.pkg.on.PostConstruct\n" +
+                "    public void getHappinessRandom(String type) {\n" +
+                "\n" +
                 "    }\n\n" +
                 "}";
 
         String newText2 = "package io.openliberty.sample.jakarta.annotations;\n\n" +
                 "import jakarta.annotation.PostConstruct;\n" +
                 "import jakarta.annotation.Resource;\n" +
-                "import testannotation.on.PostConstruct;\n\n" +
+                "import random.test.pkg.on.PostConstruct;\n\n" +
                 "@Resource(type = Object.class, name = \"aa\")\n" +
                 "public class PostConstructAnnotation {\n\n    " +
                 "private Integer studentId;\n\n    " +
@@ -137,9 +137,9 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "public void throwTantrum() throws Exception {\n        " +
                 "System.out.println(\"I'm sad\");\n    }\n\n    " +
                 "private String emailAddress;\n\n" +
-                "    @on.PostConstruct\n" +
-                "    public void nonMatchingMethod() {\n" +
-                "        System.out.println(\"This should not trigger diagnostics.\");\n" +
+                "    @random.test.pkg.on.PostConstruct\n" +
+                "    public void getHappinessRandom(String type) {\n" +
+                "\n" +
                 "    }\n\n" +
                 "}";
 

--- a/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
+++ b/src/test/java/io/openliberty/tools/intellij/lsp4jakarta/it/annotations/PostConstructAnnotationTest.java
@@ -79,8 +79,7 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "    }\n\n    @PostConstruct\n" +
                 "    public void throwTantrum() throws Exception {\n" +
                 "        System.out.println(\"I'm sad\");\n    }\n\n" +
-                "    private String emailAddress;\n\n" +
-                "}";
+                "    private String emailAddress;\n\n}";
 
         JakartaJavaCodeActionParams codeActionParams2 = createCodeActionParams(uri, d1);
         TextEdit te3 = te(0, 0, 31, 1, newText);
@@ -99,8 +98,7 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "    }\n\n    @PostConstruct\n" +
                 "    public void throwTantrum() throws Exception {\n" +
                 "        System.out.println(\"I'm sad\");\n    }\n\n" +
-                "    private String emailAddress;\n\n" +
-                "}";
+                "    private String emailAddress;\n\n}";
 
         String newText2 = "package io.openliberty.sample.jakarta.annotations;\n\n" +
                 "import jakarta.annotation.PostConstruct;\n" +
@@ -118,8 +116,7 @@ public class PostConstructAnnotationTest extends BaseJakartaTest {
                 "@PostConstruct\n    " +
                 "public void throwTantrum() throws Exception {\n        " +
                 "System.out.println(\"I'm sad\");\n    }\n\n    " +
-                "private String emailAddress;\n\n" +
-                "}";
+                "private String emailAddress;\n\n}";
 
         JakartaJavaCodeActionParams codeActionParams1 = createCodeActionParams(uri, d2);
         TextEdit te = te(0, 0, 31, 1, newText1);

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/IncorrectPostConstructAnnotation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/IncorrectPostConstructAnnotation.java
@@ -1,12 +1,18 @@
 package io.openliberty.sample.jakarta.annotations;
 
+import jakarta.annotation.Resource;
 import random.test.pkg.on.PostConstruct;
 
 @Resource(type = Object.class, name = "aa")
 public class IncorrectPostConstructAnnotation {
 
-    @random.test.pkg.on.PostConstruct
+    @PostConstruct
     public void getHappinessRandom(String type) {
+
+    }
+
+    @random.test.pkg.on.PostConstruct
+    public void getRandom(String type) {
 
     }
 

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/IncorrectPostConstructAnnotation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/IncorrectPostConstructAnnotation.java
@@ -1,0 +1,13 @@
+package io.openliberty.sample.jakarta.annotations;
+
+import random.test.pkg.on.PostConstruct;
+
+@Resource(type = Object.class, name = "aa")
+public class IncorrectPostConstructAnnotation {
+
+    @random.test.pkg.on.PostConstruct
+    public void getHappinessRandom(String type) {
+
+    }
+
+}

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
@@ -2,6 +2,8 @@ package io.openliberty.sample.jakarta.annotations;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
+import my.random.pkg.PostConstruct;
+import on.PostConstruct;
 
 @Resource(type = Object.class, name = "aa")
 public class PostConstructAnnotation {
@@ -28,5 +30,10 @@ public class PostConstructAnnotation {
     }
 
     private String emailAddress;
+
+    @ion.PostConstruct
+    public void nonMatchingMethod() {
+        System.out.println("This should not trigger diagnostics.");
+    }
 
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
@@ -2,8 +2,7 @@ package io.openliberty.sample.jakarta.annotations;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
-import my.random.pkg.PostConstruct;
-import on.PostConstruct;
+import testannotation.on.PostConstruct;
 
 @Resource(type = Object.class, name = "aa")
 public class PostConstructAnnotation {
@@ -31,7 +30,7 @@ public class PostConstructAnnotation {
 
     private String emailAddress;
 
-    @ion.PostConstruct
+    @on.PostConstruct
     public void nonMatchingMethod() {
         System.out.println("This should not trigger diagnostics.");
     }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
@@ -2,7 +2,6 @@ package io.openliberty.sample.jakarta.annotations;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
-import random.test.pkg.on.PostConstruct;
 
 @Resource(type = Object.class, name = "aa")
 public class PostConstructAnnotation {
@@ -29,10 +28,5 @@ public class PostConstructAnnotation {
     }
 
     private String emailAddress;
-
-    @random.test.pkg.on.PostConstruct
-    public void getHappinessRandom(String type) {
-
-    }
 
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/io/openliberty/sample/jakarta/annotations/PostConstructAnnotation.java
@@ -2,7 +2,7 @@ package io.openliberty.sample.jakarta.annotations;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
-import testannotation.on.PostConstruct;
+import random.test.pkg.on.PostConstruct;
 
 @Resource(type = Object.class, name = "aa")
 public class PostConstructAnnotation {
@@ -30,9 +30,9 @@ public class PostConstructAnnotation {
 
     private String emailAddress;
 
-    @on.PostConstruct
-    public void nonMatchingMethod() {
-        System.out.println("This should not trigger diagnostics.");
+    @random.test.pkg.on.PostConstruct
+    public void getHappinessRandom(String type) {
+
     }
 
 }

--- a/src/test/resources/projects/maven/jakarta-sample/src/main/java/random/test/pkg/on/PostConstruct.java
+++ b/src/test/resources/projects/maven/jakarta-sample/src/main/java/random/test/pkg/on/PostConstruct.java
@@ -1,0 +1,4 @@
+package random.test.pkg.on;
+
+public @interface PostConstruct {
+}


### PR DESCRIPTION
Adding a test to ensure no diagnostics are triggered for any non-matching annotation or import path similar to "jakarta.annotation.PostConstruct"